### PR TITLE
MeCabに未知語の品詞推定をさせない

### DIFF
--- a/Docker/n2le/mecabrc
+++ b/Docker/n2le/mecabrc
@@ -16,5 +16,5 @@ dicdir = /var/lib/mecab/dic/debian
 
 ; ChaSen
 node-format-chasen = %m\t%f[7]\t%f[6]\t%F-[0,1,2,3]\t%f[4]\t%f[5]\n
-unk-format-chasen  = %m\t%m\t%m\t%F-[0,1,2,3]\t\t\n
+unk-format-chasen  = %m\t%m\t%m\tUNKNOWN\t\t\n
 eos-format-chasen  = EOS\n


### PR DESCRIPTION
MeCabの設定を、KH CoderのWindows版パッケージと同じ設定にします。

MeCabに未知語の品詞を推定させずに、「未知語」（UNKNOWN）として出力させる設定です。分析結果の安定をはかるためです。これで漱石『こころ』の「K」が、「名詞C」と「組織名」に分かれたりしないはずです。